### PR TITLE
Typo: add word to title of example on how to use orWhereTranslationLike

### DIFF
--- a/docs/usage/scopes.md
+++ b/docs/usage/scopes.md
@@ -71,7 +71,7 @@ Post::whereTranslation('title', 'My first post')
 Post::whereTranslationLike('title', '%first%')->first();
 ```
 
-### orWhereTranslation\(string $translationField, $value, ?string $locale = null\)
+### orWhereTranslationLike\(string $translationField, $value, ?string $locale = null\)
 
 ```php
 Post::whereTranslationLike('title', '%first%')


### PR DESCRIPTION
The documentation was missing a word in the title of the example on how to use the orWhereTranslationLike method. 