### PR TITLE
Trait for simplify validation by locale

### DIFF
--- a/src/Translatable/Traits/TranslatableFormRequest.php
+++ b/src/Translatable/Traits/TranslatableFormRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Astrotomic\Translatable\Traits;
+
+use Astrotomic\Translatable\Locales;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+
+trait TranslatableFormRequest
+{
+    /**
+     * Create the default validator instance.
+     *
+     * @param  \Illuminate\Contracts\Validation\Factory  $factory
+     * @return \Illuminate\Contracts\Validation\Validator
+     */
+    protected function createDefaultValidator(ValidationFactory $factory)
+    {
+        if(!\method_exists($this, 'translatableRules'))
+            return parent::createDefaultValidator($factory);
+
+        $rules = array_merge(
+            $this->container->call([$this, 'rules']),
+            $this->makeRulesByLocales(
+                $this->container->call([$this, 'translatableRules'])
+            )
+        );
+
+        return $factory->make(
+            $this->validationData(), $rules,
+            $this->messages(), $this->attributes()
+        );
+    }
+
+    private function makeRulesByLocales($rules)
+    {
+        $locales = app('translatable.locales')->all();
+
+        $translatableRules = [];
+
+        foreach($rules as $key => $value)
+        {
+            $translatableRules[$key] = 'required|array';
+            foreach($locales as $locale) 
+            {
+                $translatableRules[$key.'.'.$locale] = $value;
+            }
+        }
+
+        return $translatableRules;
+    }
+}

--- a/src/Translatable/Traits/TranslatableFormRequest.php
+++ b/src/Translatable/Traits/TranslatableFormRequest.php
@@ -2,7 +2,6 @@
 
 namespace Astrotomic\Translatable\Traits;
 
-use Astrotomic\Translatable\Locales;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 
 trait TranslatableFormRequest
@@ -15,8 +14,9 @@ trait TranslatableFormRequest
      */
     protected function createDefaultValidator(ValidationFactory $factory)
     {
-        if(!\method_exists($this, 'translatableRules'))
+        if (! \method_exists($this, 'translatableRules')) {
             return parent::createDefaultValidator($factory);
+        }
 
         $rules = array_merge(
             $this->container->call([$this, 'rules']),
@@ -37,11 +37,9 @@ trait TranslatableFormRequest
 
         $translatableRules = [];
 
-        foreach($rules as $key => $value)
-        {
+        foreach ($rules as $key => $value) {
             $translatableRules[$key] = 'required|array';
-            foreach($locales as $locale) 
-            {
+            foreach ($locales as $locale) {
                 $translatableRules[$key.'.'.$locale] = $value;
             }
         }

--- a/tests/TranslatableFormRequestTest.php
+++ b/tests/TranslatableFormRequestTest.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 
 class TranslatableFormRequestTest extends TestsBase
 {
-    public function test_it_generate_all_rules_by_locale() 
+    public function test_it_generate_all_rules_by_locale()
     {
         $factory = m::mock(ValidationFactory::class);
 
@@ -31,10 +31,12 @@ class TranslatableFormRequestTest extends TestsBase
         static::getMethod('createDefaultValidator')->invokeArgs($request, [$factory]);
     }
 
-    protected static function getMethod($name) {
+    protected static function getMethod($name)
+    {
         $class = new ReflectionClass(DummyFormRequest::class);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
+
         return $method;
-      }
+    }
 }

--- a/tests/TranslatableFormRequestTest.php
+++ b/tests/TranslatableFormRequestTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Mockery as m;
+use Astrotomic\Translatable\Test\Request\DummyFormRequest;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+
+class TranslatableFormRequestTest extends TestsBase
+{
+    public function test_it_generate_all_rules_by_locale() 
+    {
+        $factory = m::mock(ValidationFactory::class);
+
+        $factory->shouldReceive('make')
+            ->with([], [
+                'name' => 'required',
+                'title' => 'required|array',
+                'title.el' => 'string',
+                'title.en' => 'string',
+                'title.fr' => 'string',
+                'title.de' => 'string',
+                'title.id' => 'string',
+                'title.en-GB' => 'string',
+                'title.en-US' => 'string',
+                'title.de-DE' => 'string',
+                'title.de-CH' => 'string',
+            ], [], []);
+
+        $request = DummyFormRequest::createFromGlobals()
+            ->setContainer(app());
+
+        static::getMethod('createDefaultValidator')->invokeArgs($request, [$factory]);
+    }
+
+    protected static function getMethod($name) {
+        $class = new ReflectionClass(DummyFormRequest::class);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method;
+      }
+}

--- a/tests/requests/DummyFormRequest.php
+++ b/tests/requests/DummyFormRequest.php
@@ -8,7 +8,7 @@ use Astrotomic\Translatable\Traits\TranslatableFormRequest;
 class DummyFormRequest extends FormRequest
 {
     use TranslatableFormRequest;
-    
+
     public function rules()
     {
         return [

--- a/tests/requests/DummyFormRequest.php
+++ b/tests/requests/DummyFormRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Astrotomic\Translatable\Test\Request;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Astrotomic\Translatable\Traits\TranslatableFormRequest;
+
+class DummyFormRequest extends FormRequest
+{
+    use TranslatableFormRequest;
+    
+    public function rules()
+    {
+        return [
+            'name' => 'required',
+        ];
+    }
+
+    public function translatableRules()
+    {
+        return [
+            'title' => 'string',
+        ];
+    }
+}


### PR DESCRIPTION
Create trait `Astrotomic\Translatable\Traits\TranslatableFormRequest` for simplify validation rules on FormRequest.

```php
class DummyFormRequest extends FormRequest
{
    use TranslatableFormRequest;
    
    public function rules()
    {
        return [
            'name' => 'required',
        ];
    }

    public function translatableRules()
    {
        return [
            'title' => 'string',
        ];
    }
}
```

This trait generate rules for all available locales :

- name : string
- title : required|array
- title.fr : string
- title.en : string

See the `tests/TranslatableFormRequestTest.php` for more details