### PR TITLE
Add auto fallback feature

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -184,9 +184,7 @@ trait Translatable
         } elseif ($withFallback && $configFallbackLocale == null) {
             $configuredLocales = $this->getLocalesHelper()->all();
             foreach ($configuredLocales as $configuredLocale) {
-                if ($translation = $this->getTranslationByLocaleKey($configuredLocale)) {
-                    return $translation;
-                }
+                if ($translation = $this->getTranslationByLocaleKey($configuredLocale)) return $translation;
             }
         }
     }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -170,23 +170,36 @@ trait Translatable
         if ($translation = $this->getTranslationByLocaleKey($locale)) {
             return $translation;
         }
-        if ($withFallback && $fallbackLocale) {
-            if ($translation = $this->getTranslationByLocaleKey($fallbackLocale)
-               || (
-                   is_string($configFallbackLocale)
-                   && $fallbackLocale !== $configFallbackLocale
-                   && $translation = $this->getTranslationByLocaleKey($configFallbackLocale))
-               ) {
+        if ($translation = $this->getFallbackTranslation($locale)) {
+            return $translation;
+        }
+
+        return null;
+    }
+    
+    public function getFallbackTranslation(?string $locale = null): ?Model {
+        $configFallbackLocale = $this->getFallbackLocale();
+        $fallbackLocale = $this->getFallbackLocale($locale);
+        
+        if ($fallbackLocale) {
+            if ($translation = $this->getTranslationByLocaleKey($fallbackLocale)) {
                 return $translation;
             }
-        } elseif ($withFallback && $configFallbackLocale == null) {
-            foreach ($this->getLocalesHelper()->all() as $configuredLocale) {
+            if (
+                is_string($configFallbackLocale)
+                && $fallbackLocale !== $configFallbackLocale
+                && $translation = $this->getTranslationByLocaleKey($configFallbackLocale)
+            ) {
+                return $translation;
+            }
+        } else if($configFallbackLocale == null) {
+            foreach($this->getLocalesHelper()->all() as $configuredLocale) {
                 if ($translation = $this->getTranslationByLocaleKey($configuredLocale)) {
                     return $translation;
                 }
             }
         }
-
+        
         return null;
     }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -182,9 +182,10 @@ trait Translatable
                 return $translation;
             }
         } elseif ($withFallback && $configFallbackLocale == null) {
-            $configuredLocales = $this->getLocalesHelper()->all();
-            foreach ($configuredLocales as $configuredLocale) {
-                if ($translation = $this->getTranslationByLocaleKey($configuredLocale)) return $translation;
+            foreach ($this->getLocalesHelper()->all() as $configuredLocale) {
+                if ($translation = $this->getTranslationByLocaleKey($configuredLocale)) {
+                    return $translation;
+                }
             }
         }
     }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -186,7 +186,7 @@ trait Translatable
                 }
             }
         }
-        
+
         return null;
     }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -177,10 +177,11 @@ trait Translatable
         return null;
     }
     
-    public function getFallbackTranslation(?string $locale = null): ?Model {
+    public function getFallbackTranslation(?string $locale = null): ?Model
+    {
         $configFallbackLocale = $this->getFallbackLocale();
         $fallbackLocale = $this->getFallbackLocale($locale);
-        
+
         if ($fallbackLocale) {
             if ($translation = $this->getTranslationByLocaleKey($fallbackLocale)) {
                 return $translation;
@@ -192,7 +193,7 @@ trait Translatable
             ) {
                 return $translation;
             }
-        } else if($configFallbackLocale == null) {
+        } elseif($configFallbackLocale == null) {
             foreach($this->getLocalesHelper()->all() as $configuredLocale) {
                 if ($translation = $this->getTranslationByLocaleKey($configuredLocale)) {
                     return $translation;

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -181,6 +181,14 @@ trait Translatable
             ) {
                 return $translation;
             }
+        } else if($withFallback && $configFallbackLocale == null) {
+            //Use first available locale as fallback
+            $configured_locales = $this->getLocalesHelper()->all();
+            foreach($configured_locales as $configured_locale) {
+                if ($translation = $this->getTranslationByLocaleKey($configured_locale)) {
+                    return $translation;
+                }
+            }
         }
 
         return null;

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -176,7 +176,7 @@ trait Translatable
 
         return null;
     }
-    
+
     public function getFallbackTranslation(?string $locale = null): ?Model
     {
         $configFallbackLocale = $this->getFallbackLocale();
@@ -193,8 +193,8 @@ trait Translatable
             ) {
                 return $translation;
             }
-        } elseif($configFallbackLocale == null) {
-            foreach($this->getLocalesHelper()->all() as $configuredLocale) {
+        } elseif ($configFallbackLocale == null) {
+            foreach ($this->getLocalesHelper()->all() as $configuredLocale) {
                 if ($translation = $this->getTranslationByLocaleKey($configuredLocale)) {
                     return $translation;
                 }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -181,17 +181,18 @@ trait Translatable
         $configFallbackLocale = $this->getFallbackLocale();
         $fallbackLocale = $this->getFallbackLocale($locale);
 
-        if ($fallbackLocale) {
-            if ($translation = $this->getTranslationByLocaleKey($fallbackLocale)) {
-                return $translation;
-            }
-            if (
-                is_string($configFallbackLocale)
-                && $fallbackLocale !== $configFallbackLocale
-                && $translation = $this->getTranslationByLocaleKey($configFallbackLocale)
-            ) {
-                return $translation;
-            }
+        if (
+            $fallbackLocale
+            && $translation = $this->getTranslationByLocaleKey($fallbackLocale)
+        ) {
+            return $translation;
+        } elseif (
+            $fallbackLocale
+            && is_string($configFallbackLocale)
+            && $fallbackLocale !== $configFallbackLocale
+            && $translation = $this->getTranslationByLocaleKey($configFallbackLocale)
+        ) {
+            return $translation;
         } elseif ($configFallbackLocale == null) {
             foreach ($this->getLocalesHelper()->all() as $configuredLocale) {
                 if ($translation = $this->getTranslationByLocaleKey($configuredLocale)) {

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -162,15 +162,14 @@ trait Translatable
 
     public function getTranslation(?string $locale = null, bool $withFallback = null): ?Model
     {
-        $configFallbackLocale = $this->getFallbackLocale();
         $locale = $locale ?: $this->locale();
         $withFallback = $withFallback === null ? $this->useFallback() : $withFallback;
-        $fallbackLocale = $this->getFallbackLocale($locale);
 
         if ($translation = $this->getTranslationByLocaleKey($locale)) {
             return $translation;
         }
-        if ($translation = $this->getFallbackTranslation($locale)) {
+        if ($withFallback
+            && $translation = $this->getFallbackTranslation($locale)) {
             return $translation;
         }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -199,7 +199,7 @@ trait Translatable
                 }
             }
         }
-        
+
         return null;
     }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -182,16 +182,13 @@ trait Translatable
                 return $translation;
             }
         } elseif ($withFallback && $configFallbackLocale == null) {
-            //Use first available locale as fallback
-            $configured_locales = $this->getLocalesHelper()->all();
-            foreach ($configured_locales as $configured_locale) {
-                if ($translation = $this->getTranslationByLocaleKey($configured_locale)) {
+            $configuredLocales = $this->getLocalesHelper()->all();
+            foreach ($configuredLocales as $configuredLocale) {
+                if ($translation = $this->getTranslationByLocaleKey($configuredLocale)) {
                     return $translation;
                 }
             }
         }
-
-        return null;
     }
 
     public function getTranslationOrNew(?string $locale = null): Model

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -171,14 +171,12 @@ trait Translatable
             return $translation;
         }
         if ($withFallback && $fallbackLocale) {
-            if ($translation = $this->getTranslationByLocaleKey($fallbackLocale)) {
-                return $translation;
-            }
-            if (
-                is_string($configFallbackLocale)
-                && $fallbackLocale !== $configFallbackLocale
-                && $translation = $this->getTranslationByLocaleKey($configFallbackLocale)
-            ) {
+            if ($translation = $this->getTranslationByLocaleKey($fallbackLocale)
+               || (
+                   is_string($configFallbackLocale)
+                   && $fallbackLocale !== $configFallbackLocale
+                   && $translation = $this->getTranslationByLocaleKey($configFallbackLocale))
+               ) {
                 return $translation;
             }
         } elseif ($withFallback && $configFallbackLocale == null) {
@@ -188,6 +186,8 @@ trait Translatable
                 }
             }
         }
+        
+        return null;
     }
 
     public function getTranslationOrNew(?string $locale = null): Model

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -181,10 +181,10 @@ trait Translatable
             ) {
                 return $translation;
             }
-        } else if($withFallback && $configFallbackLocale == null) {
+        } elseif ($withFallback && $configFallbackLocale == null) {
             //Use first available locale as fallback
             $configured_locales = $this->getLocalesHelper()->all();
-            foreach($configured_locales as $configured_locale) {
+            foreach ($configured_locales as $configured_locale) {
                 if ($translation = $this->getTranslationByLocaleKey($configured_locale)) {
                     return $translation;
                 }

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -189,6 +189,8 @@ trait Translatable
                 }
             }
         }
+
+        return null;
     }
 
     public function getTranslationOrNew(?string $locale = null): Model

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -162,46 +162,33 @@ trait Translatable
 
     public function getTranslation(?string $locale = null, bool $withFallback = null): ?Model
     {
+        $configFallbackLocale = $this->getFallbackLocale();
         $locale = $locale ?: $this->locale();
         $withFallback = $withFallback === null ? $this->useFallback() : $withFallback;
+        $fallbackLocale = $this->getFallbackLocale($locale);
 
         if ($translation = $this->getTranslationByLocaleKey($locale)) {
             return $translation;
         }
-        if ($withFallback
-            && $translation = $this->getFallbackTranslation($locale)) {
-            return $translation;
-        }
-
-        return null;
-    }
-
-    public function getFallbackTranslation(?string $locale = null): ?Model
-    {
-        $configFallbackLocale = $this->getFallbackLocale();
-        $fallbackLocale = $this->getFallbackLocale($locale);
-
-        if (
-            $fallbackLocale
-            && $translation = $this->getTranslationByLocaleKey($fallbackLocale)
-        ) {
-            return $translation;
-        } elseif (
-            $fallbackLocale
-            && is_string($configFallbackLocale)
-            && $fallbackLocale !== $configFallbackLocale
-            && $translation = $this->getTranslationByLocaleKey($configFallbackLocale)
-        ) {
-            return $translation;
-        } elseif ($configFallbackLocale == null) {
-            foreach ($this->getLocalesHelper()->all() as $configuredLocale) {
+        if ($withFallback && $fallbackLocale) {
+            if ($translation = $this->getTranslationByLocaleKey($fallbackLocale)) {
+                return $translation;
+            }
+            if (
+                is_string($configFallbackLocale)
+                && $fallbackLocale !== $configFallbackLocale
+                && $translation = $this->getTranslationByLocaleKey($configFallbackLocale)
+            ) {
+                return $translation;
+            }
+        } elseif ($withFallback && $configFallbackLocale == null) {
+            $configuredLocales = $this->getLocalesHelper()->all();
+            foreach ($configuredLocales as $configuredLocale) {
                 if ($translation = $this->getTranslationByLocaleKey($configuredLocale)) {
                     return $translation;
                 }
             }
         }
-
-        return null;
     }
 
     public function getTranslationOrNew(?string $locale = null): Model


### PR DESCRIPTION
Currently, only one fallback locale can be used and it has to be predetermined in config. Auto fallback means looping through available locales (in configuration order) and using the first available translation. I believe this is much more realistic than using a specified fallback locale.

This commit generates no conflicts or unwanted operation, as this feature only operates if fallback_locale in configuration is set to null (null value is not used for anything currently). Way of loading translations neither affected.