### PR TITLE
Use `translation` relation in eager loading to avoid loading of all `translations`.

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -391,7 +391,7 @@ trait Translatable
 
     private function getTranslationByLocaleKey(string $key): ?Model
     {
-        if(
+        if (
             $this->relationLoaded('translation')
             && $this->translation
             && $this->translation->getAttribute($this->getLocaleKey()) == $key

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -397,9 +397,9 @@ trait Translatable
             && $this->translation->getAttribute($this->getLocaleKey()) == $key
         ) {
             return $this->translation;
-        } else {
-            return $this->translations->firstWhere($this->getLocaleKey(), $key);
         }
+
+        return $this->translations->firstWhere($this->getLocaleKey(), $key);
     }
 
     private function toArrayAlwaysLoadsTranslations(): bool

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -391,7 +391,15 @@ trait Translatable
 
     private function getTranslationByLocaleKey(string $key): ?Model
     {
-        return $this->translations->firstWhere($this->getLocaleKey(), $key);
+        if(
+            $this->relationLoaded('translation')
+            && $this->translation
+            && $this->translation->getAttribute($this->getLocaleKey()) == $key
+        ) {
+            return $this->translation;
+        } else {
+            return $this->translations->firstWhere($this->getLocaleKey(), $key);
+        }
     }
 
     private function toArrayAlwaysLoadsTranslations(): bool


### PR DESCRIPTION
In most times we need only one translation, and don't need to load all translations of model.

**We can't use this now:**

```
$models = Model::with('relation.translation', 'translation')->get();
foreach($models as $model){
    $model->title;
}
```

`getTranslationByLocaleKey()` method ignores `translation()` relation and use `translations()`.

<img width="657" alt="Снимок экрана 2019-08-18 в 16 22 48" src="https://user-images.githubusercontent.com/49863998/63224991-9a738400-c1d4-11e9-8c87-e8efa7d7de10.png">

<img width="1675" alt="Снимок экрана 2019-08-18 в 16 22 35" src="https://user-images.githubusercontent.com/49863998/63224993-9fd0ce80-c1d4-11e9-9e57-5322cd1f3b8a.png">
