### PR TITLE
Allows to load `translation` relation instead of load all `translations`.

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -391,6 +391,14 @@ trait Translatable
 
     private function getTranslationByLocaleKey(string $key): ?Model
     {
+        if (
+            $this->relationLoaded('translation')
+            && $this->translation
+            && $this->translation->getAttribute($this->getLocaleKey()) == $key
+        ) {
+            return $this->translation;
+        }
+
         return $this->translations->firstWhere($this->getLocaleKey(), $key);
     }
 


### PR DESCRIPTION
Most times we need only one translation, and don't need to load all translations of model.

We can't use this now:

```
$models = Model::with('translation')->get();
foreach($models as $model){
    echo $model->title;
}
```

Method `getTranslationByLocaleKey()` ignores `translation()` relation and always use `translations()` relation, which loads all translations instead of load only one, that we need. 

<img width="657" alt="Снимок экрана 2019-08-18 в 16 22 48" src="https://user-images.githubusercontent.com/49863998/63225310-fc34ed80-c1d6-11e9-8ba2-b6e60a440300.png">

<img width="1675" alt="Снимок экрана 2019-08-18 в 16 22 35" src="https://user-images.githubusercontent.com/49863998/63225312-fd661a80-c1d6-11e9-9054-7009cc7b5b76.png">
