### PR TITLE
Get all translations when ordering by locale

### DIFF
--- a/src/Translatable/Traits/Scopes.php
+++ b/src/Translatable/Traits/Scopes.php
@@ -57,14 +57,13 @@ trait Scopes
 
         return $query
             ->with('translations')
-            ->select($table.'.*')
+            ->select("{$table}.*")
             ->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $localeKey, $table, $keyName) {
                 $join
-                    ->on($translationTable.'.'.$this->getTranslationRelationKey(), '=', $table.'.'.$keyName)
-                    ->where($translationTable.'.'.$localeKey, $this->locale());
+                    ->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$keyName}")
+                    ->where("{$translationTable}.{$localeKey}", $this->locale());
             })
-            ->orderByRaw("CASE WHEN {$translationTable}.{$translationField} = '{$this->locale()}' THEN 1 ELSE 2 END")
-            ->orderBy("{$translationTable}.{$localeKey}", $sortMethod);
+            ->orderBy("{$translationTable}.{$translationField}", $sortMethod);
     }
 
     public function scopeOrWhereTranslation(Builder $query, string $translationField, $value, ?string $locale = null)

--- a/src/Translatable/Traits/Scopes.php
+++ b/src/Translatable/Traits/Scopes.php
@@ -56,14 +56,15 @@ trait Scopes
         $keyName = $this->getKeyName();
 
         return $query
-            ->join($translationTable, function (JoinClause $join) use ($translationTable, $localeKey, $table, $keyName) {
+            ->with('translations')
+            ->select($table.'.*')
+            ->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $localeKey, $table, $keyName) {
                 $join
                     ->on($translationTable.'.'.$this->getTranslationRelationKey(), '=', $table.'.'.$keyName)
                     ->where($translationTable.'.'.$localeKey, $this->locale());
             })
-            ->orderBy($translationTable.'.'.$translationField, $sortMethod)
-            ->select($table.'.*')
-            ->with('translations');
+            ->orderByRaw("CASE WHEN {$translationTable}.{$translationField} = '{$this->locale()}' THEN 1 ELSE 2 END")
+            ->orderBy("{$translationTable}.{$localeKey}", $sortMethod);
     }
 
     public function scopeOrWhereTranslation(Builder $query, string $translationField, $value, ?string $locale = null)

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Astrotomic\Translatable\Test\Model\Country;
 use Astrotomic\Translatable\Test\Model\Food;
+use Astrotomic\Translatable\Test\Model\Country;
 use Astrotomic\Translatable\Test\Model\Vegetable;
 
 final class ScopesTest extends TestsBase
@@ -213,11 +213,10 @@ final class ScopesTest extends TestsBase
         $this->assertSame(1, $result->first()->id);
     }
 
-
     public function test_orderByTranslation_sorts_by_key_asc_even_if_locale_is_missing()
     {
-        Food::create(['en' => ['name' => 'Potatoes'],'fr' => ['name' => 'Pommes de Terre']]);
-        Food::create(['en' => ['name' => 'Strawberries'],'fr' => ['name' => 'Fraises']]);
+        Food::create(['en' => ['name' => 'Potatoes'], 'fr' => ['name' => 'Pommes de Terre']]);
+        Food::create(['en' => ['name' => 'Strawberries'], 'fr' => ['name' => 'Fraises']]);
         Food::create([]);
 
         $orderInEnglish = Food::with('translations')->orderByTranslation('name')->get();

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Astrotomic\Translatable\Test\Model\Country;
+use Astrotomic\Translatable\Test\Model\Food;
 use Astrotomic\Translatable\Test\Model\Vegetable;
 
 final class ScopesTest extends TestsBase
@@ -215,8 +216,15 @@ final class ScopesTest extends TestsBase
 
     public function test_orderByTranslation_sorts_by_key_asc_even_if_locale_is_missing()
     {
-        App::setLocale('ca');
-        $result = Country::orderByTranslation('name')->count();
-        $this->assertSame(4, $result);
+        Food::create(['en' => ['name' => 'Potatoes'],'fr' => ['name' => 'Pommes de Terre']]);
+        Food::create(['en' => ['name' => 'Strawberries'],'fr' => ['name' => 'Fraises']]);
+        Food::create([]);
+
+        $orderInEnglish = Food::with('translations')->orderByTranslation('name')->get();
+        $this->assertEquals([null, 'Potatoes', 'Strawberries'], $orderInEnglish->pluck('name')->toArray());
+
+        App::setLocale('fr');
+        $orderInFrench = Food::with('translations')->orderByTranslation('name', 'desc')->get();
+        $this->assertEquals(['Pommes de Terre', 'Fraises', null], $orderInFrench->pluck('name')->toArray());
     }
 }

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -203,12 +203,20 @@ final class ScopesTest extends TestsBase
     public function test_orderByTranslation_sorts_by_key_asc()
     {
         $result = Country::orderByTranslation('name')->get();
-        $this->assertSame(2, $result->first()->id);
+        $this->assertSame(3, $result->first()->id);
     }
 
     public function test_orderByTranslation_sorts_by_key_desc()
     {
         $result = Country::orderByTranslation('name', 'desc')->get();
         $this->assertSame(1, $result->first()->id);
+    }
+
+
+    public function test_orderByTranslation_sorts_by_key_asc_even_if_locale_is_missing()
+    {
+        App::setLocale('ca');
+        $result = Country::orderByTranslation('name')->count();
+        $this->assertSame(4, $result);
     }
 }


### PR DESCRIPTION
The issue was that by doing a `join` it didn't join the records that are missing translations in the desired locale. By doing a `leftJoin` we get that records anyway and, adding the `orderByRaw`, we ensure to get first those records translated in the `locale` we want.

I'm sure it will need further modifications, let me know of any required change @Gummibeer 

Fixes #71