### PR TITLE
drop outdated laravel versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
+  - 7.1
   - 7.2
   - 7.3
 
@@ -24,6 +25,11 @@ matrix:
     - php: 7.4snapshot
       env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.4snapshot
+      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-stable'
+  exclude:
+    - php: 7.1
+      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.1
       env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-stable'
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,10 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 
 env:
-  - LARAVEL='5.6.*' COMPOSER_FLAGS='--prefer-lowest'
-  - LARAVEL='5.6.*' COMPOSER_FLAGS='--prefer-stable'
-  - LARAVEL='5.7.*' COMPOSER_FLAGS='--prefer-lowest'
-  - LARAVEL='5.7.*' COMPOSER_FLAGS='--prefer-stable'
   - LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-lowest'
   - LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-stable'
   - LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-lowest'
@@ -29,15 +24,6 @@ matrix:
     - php: 7.4snapshot
       env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.4snapshot
-      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-stable'
-  exclude:
-    - php: 7.3
-      env: LARAVEL='5.6.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.3
-      env: LARAVEL='5.6.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.1
-      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.1
       env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-stable'
   fast_finish: true
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "illuminate/contracts": "5.6.* || 5.7.* || 5.8.* || ^6.0",
-        "illuminate/database": "5.6.* || 5.7.* || 5.8.* || ^6.0",
-        "illuminate/support": "5.6.* || 5.7.* || 5.8.* || ^6.0"
+        "illuminate/contracts": "5.8.* || ^6.0",
+        "illuminate/database": "5.8.* || ^6.0",
+        "illuminate/support": "5.8.* || ^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "3.6.* || 3.7.* || 3.8.* || ^4.0"
+        "orchestra/testbench": "3.8.* || ^4.0"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "illuminate/support": "5.8.* || ^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "3.8.* || ^4.0"
+        "orchestra/testbench": "3.8.* || ^4.0",
+        "phpunit/phpunit": "^8.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Laravel 5.6 & 5.7 are out of support. They would require adjusted tests - so support is dropped now.
https://laravel.com/docs/master/releases

#75 