### PR TITLE
Delete translations on cascade

### DIFF
--- a/src/Translatable/Contracts/Translatable.php
+++ b/src/Translatable/Contracts/Translatable.php
@@ -14,6 +14,12 @@ interface Translatable
 
     public static function enableAutoloadTranslations(): void;
 
+    public static function defaultDeleteTranslationsCascade(): void;
+
+    public static function disableDeleteTranslationsCascade(): void;
+
+    public static function enableDeleteTranslationsCascade(): void;
+
     public function deleteTranslations($locales = null): void;
 
     public function getDefaultLocale(): ?string;

--- a/src/Translatable/Contracts/Translatable.php
+++ b/src/Translatable/Contracts/Translatable.php
@@ -14,8 +14,6 @@ interface Translatable
 
     public static function enableAutoloadTranslations(): void;
 
-    public static function defaultDeleteTranslationsCascade(): void;
-
     public static function disableDeleteTranslationsCascade(): void;
 
     public static function enableDeleteTranslationsCascade(): void;

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -57,11 +57,6 @@ trait Translatable
         self::$autoloadTranslations = true;
     }
 
-    public static function defaultDeleteTranslationsCascade(): void
-    {
-        self::$deleteTranslationsCascade = false;
-    }
-
     public static function disableDeleteTranslationsCascade(): void
     {
         self::$deleteTranslationsCascade = false;

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -24,6 +24,8 @@ trait Translatable
 
     protected static $autoloadTranslations = null;
 
+    protected static $deleteTranslationsCascade = false;
+
     protected $defaultLocale;
 
     public static function bootTranslatable(): void
@@ -31,6 +33,12 @@ trait Translatable
         static::saved(function (Model $model) {
             /* @var Translatable $model */
             return $model->saveTranslations();
+        });
+
+        static::deleted(function (Model $model) {
+            if (self::$deleteTranslationsCascade === true) {
+                return $model->deleteTranslations();
+            }
         });
     }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -57,6 +57,21 @@ trait Translatable
         self::$autoloadTranslations = true;
     }
 
+    public static function defaultDeleteTranslationsCascade(): void
+    {
+        self::$deleteTranslationsCascade = false;
+    }
+
+    public static function disableDeleteTranslationsCascade(): void
+    {
+        self::$deleteTranslationsCascade = false;
+    }
+
+    public static function enableDeleteTranslationsCascade(): void
+    {
+        self::$deleteTranslationsCascade = true;
+    }
+
     public function attributesToArray()
     {
         $attributes = parent::attributesToArray();

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -1027,4 +1027,16 @@ final class TranslatableTest extends TestCase
 
         $this->assertDatabaseMissing('vegetable_translations', ['vegetable_identity' => $vegetable->identity]);
     }
+
+    /** @test */
+    public function it_does_not_delete_on_cascade_after_retrieving_a_model()
+    {
+        Vegetable::enableDeleteTranslationsCascade();
+        $vegetable = factory(Vegetable::class)->create(['name:en' => 'Peas']);
+        Vegetable::disableDeleteTranslationsCascade();
+
+        $vegetable->delete();
+
+        $this->assertDatabaseHas('vegetable_translations', ['vegetable_identity' => $vegetable->identity]);
+    }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -1020,11 +1020,8 @@ final class TranslatableTest extends TestCase
     /** @test */
     public function it_deletes_translations_on_cascade()
     {
-        $vegetable = new class(['name:en']) extends Vegetable {
-            protected $table = 'vegetables';
-            protected static $deleteTranslationsCascade = true;
-        };
-        $vegetable->save();
+        Vegetable::enableDeleteTranslationsCascade();
+        $vegetable = factory(Vegetable::class)->create(['name:en' => 'Peas']);
 
         $vegetable->delete();
 

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -1006,4 +1006,28 @@ final class TranslatableTest extends TestCase
         static::assertFalse($country->relationLoaded('translation'));
         static::assertTrue($country->relationLoaded('translations'));
     }
+
+    /** @test */
+    public function it_does_not_delete_translations_on_cascade_by_default()
+    {
+        $vegetable = factory(Vegetable::class)->create(['name:en' => 'Peas']);
+
+        $vegetable->delete();
+
+        $this->assertDatabaseHas('vegetable_translations', ['vegetable_identity' => $vegetable->identity]);
+    }
+
+    /** @test */
+    public function it_deletes_translations_on_cascade()
+    {
+        $vegetable = new class(['name:en']) extends Vegetable {
+            protected $table = 'vegetables';
+            protected static $deleteTranslationsCascade = true;
+        };
+        $vegetable->save();
+
+        $vegetable->delete();
+
+        $this->assertDatabaseMissing('vegetable_translations', ['vegetable_identity' => $vegetable->identity]);
+    }
 }

--- a/tests/migrations/2013_11_28_152610_create_tables.php
+++ b/tests/migrations/2013_11_28_152610_create_tables.php
@@ -107,7 +107,7 @@ class CreateTables extends Migration
             $table->string('locale')->index();
 
             $table->unique(['vegetable_identity', 'locale']);
-            $table->foreign('vegetable_identity')->references('identity')->on('vegetables')->onDelete('cascade');
+            $table->foreign('vegetable_identity')->references('identity')->on('vegetables');
         });
 
         $this->schema->create('people', function (Blueprint $table) {


### PR DESCRIPTION
After talking to @Gummibeer, we decided to add this feature as a model-level property.

Iterating over each model will preserve the soft-deletes or other custom code the user could have written overriding `delete` method on the models.

Fixes #85 