### PR TITLE
Fix deleting event

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -35,7 +35,7 @@ trait Translatable
             return $model->saveTranslations();
         });
 
-        static::deleted(function (Model $model) {
+        static::deleting(function (Model $model) {
             if (self::$deleteTranslationsCascade === true) {
                 return $model->deleteTranslations();
             }


### PR DESCRIPTION
Deleted event will fire after delete the parent record and it will make error while deleting returned from MySQL so we should set deleting event to fire this script before deleting the parent record.