### PR TITLE
Added translateOrFail method to translatable trait

### DIFF
--- a/docs/usage/methods.md
+++ b/docs/usage/methods.md
@@ -46,6 +46,16 @@ $post->translateOrNew('fr'); // returns the french translation model
 $post->translateOrNew('it'); // returns the new italian translation model
 ```
 
+### translateOrFail\(string $locale\)
+
+**Alias of:** `getTranslationOrFail(string $locale)`
+
+This returns an instance of `PostTranslation` using the given locale and will throw a ModelNotFoundException if none exists.
+
+```php
+$post->translateOrFail('fr'); // returns the french translation model
+```
+
 ## hasTranslation\(?string $locale = null\)
 
 Check if the post has a translation in default or given locale.

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -6,6 +6,7 @@ use Astrotomic\Translatable\Traits\Relationship;
 use Astrotomic\Translatable\Traits\Scopes;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Str;
 
 /**
@@ -238,6 +239,15 @@ trait Translatable
         return $translation;
     }
 
+    public function getTranslationOrFail(string $locale): Model
+    {
+        if (($translation = $this->getTranslation($locale, false)) === null) {
+            throw new ModelNotFoundException();
+        }
+
+        return $translation;
+    }
+
     public function getTranslationsArray(): array
     {
         $translations = [];
@@ -315,6 +325,11 @@ trait Translatable
     public function translateOrNew(?string $locale = null): Model
     {
         return $this->getTranslationOrNew($locale);
+    }
+
+    public function translateOrFail(string $locale): Model
+    {
+        return $this->getTranslationOrFail($locale);
     }
 
     protected function getLocalesHelper(): Locales

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -10,6 +10,7 @@ use Astrotomic\Translatable\Tests\Eloquent\Person;
 use Astrotomic\Translatable\Tests\Eloquent\Vegetable;
 use Astrotomic\Translatable\Tests\Eloquent\VegetableTranslation;
 use Illuminate\Database\Eloquent\MassAssignmentException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
@@ -412,6 +413,18 @@ final class TranslatableTest extends TestCase
 
         $this->app->setLocale('xyz');
         static::assertEquals('xyz', $vegetable->translateOrNew()->locale);
+    }
+
+    /** @test */
+    public function it_has_methods_that_throw_an_exception_if_translation_does_not_exist(): void
+    {
+        $vegetable = Vegetable::create([
+            'en' => ['name' => 'Peas'],
+        ]);
+        static::assertEquals('en', $vegetable->translateOrFail('en')->locale);
+        
+        $this->expectException(ModelNotFoundException::class);
+        $vegetable->translateOrFail('xyz');
     }
 
     /** @test */

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -416,13 +416,13 @@ final class TranslatableTest extends TestCase
     }
 
     /** @test */
-    public function it_has_methods_that_throw_an_exception_if_translation_does_not_exist(): void
+    public function it_throws_an_exception_if_translation_does_not_exist(): void
     {
         $vegetable = Vegetable::create([
             'en' => ['name' => 'Peas'],
         ]);
         static::assertEquals('en', $vegetable->translateOrFail('en')->locale);
-        
+
         $this->expectException(ModelNotFoundException::class);
         $vegetable->translateOrFail('xyz');
     }


### PR DESCRIPTION
Hi, I thought it would be useful to have a convenience method that throws a ModelNotFoundException if a translation does not exist, mimicking the behaviour of Eloquent's findOrFail(). Thanks for the project :smile: 