### PR TITLE
Add .gitattributes to exclude some files from production environments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+/.github export-ignore
+/.php_cs export-ignore
+/.gitbook.yaml export-ignore
+/.styleci.yml export-ignore
+/.gitattributes export-ignore
+/.scrutinizer.yml export-ignore
+/docs export-ignore
+/.codeclimate.yml export-ignore
+
+# phpunit.xml.dist and tests are not excluded so tests can be run
+# this is usefull if this package ends up one day in Debian


### PR DESCRIPTION
`git archive fixes | gzip > fixes-branch.tgz` where `fixes` is the branch name

to have a try of the effect on composer installs you can use my lib https://github.com/williamdes/mariadb-mysql-kbs