### PR TITLE
Fixes updating issue when used with Laravel Nova

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -367,7 +367,15 @@ trait Translatable
             return $saved;
         }
 
-        foreach ($this->translations as $translation) {
+        // For Laravel Nova: the translation is populated by Nova with the updated fields
+        if (isset($this->translation) && $this->isTranslationDirty($this->translation)) {
+            if (! empty($connectionName = $this->getConnectionName())) {
+                $this->translation->setConnection($connectionName);
+            }
+
+            $this->translation->setAttribute($this->getTranslationRelationKey(), $this->getKey());
+            $saved = $this->translation->save();
+        } else foreach ($this->translations as $translation) {
             if ($saved && $this->isTranslationDirty($translation)) {
                 if (! empty($connectionName = $this->getConnectionName())) {
                     $translation->setConnection($connectionName);

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -367,15 +367,9 @@ trait Translatable
             return $saved;
         }
 
-        // For Laravel Nova: the translation is populated by Nova with the updated fields
-        if (isset($this->translation) && $this->isTranslationDirty($this->translation)) {
-            if (! empty($connectionName = $this->getConnectionName())) {
-                $this->translation->setConnection($connectionName);
-            }
-
-            $this->translation->setAttribute($this->getTranslationRelationKey(), $this->getKey());
-            $saved = $this->translation->save();
-        } else foreach ($this->translations as $translation) {
+        // Nova populates the translation with the updated fields
+        $translations = isset($this->translation) && $this->isTranslationDirty($this->translation) ? [$this->translation] : $this->translations;
+        foreach ($translations as $translation) {
             if ($saved && $this->isTranslationDirty($translation)) {
                 if (! empty($connectionName = $this->getConnectionName())) {
                     $translation->setConnection($connectionName);


### PR DESCRIPTION
This checks if a translation object exists on the model, which only exists when loaded through Nova with the language field.
This should be enough for this package to officially support Laravel Nova :)

Hope you can publish this asap as I use it in production already.