### PR TITLE
Laravel 8.0 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,7 @@ jobs:
         include:
           - laravel: 8.*
             testbench: 6.*
+            legacy: laravel/legacy-factories
           - laravel: 7.*
             testbench: 5.*
           - laravel: 6.*
@@ -58,7 +59,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" ${{ matrix.legacy }} --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,10 +15,12 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.4, 7.3, 7.2]
-        laravel: [7.*, 6.*, 5.8.*]
+        laravel: [8.*, 7.*, 6.*, 5.8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
+          - laravel: 8.*
+            testbench: 6.*
           - laravel: 7.*
             testbench: 5.*
           - laravel: 6.*
@@ -28,6 +30,8 @@ jobs:
         exclude:
           - php: 7.4
             laravel: 5.8.*
+          - php: 7.2
+            laravel: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - laravel: 8.*
             testbench: 6.*
-            legacy: laravel/legacy-factories
+            legacy: "laravel/legacy-factories:^1.0.4"
           - laravel: 7.*
             testbench: 5.*
           - laravel: 6.*

--- a/composer.json
+++ b/composer.json
@@ -1,69 +1,69 @@
 {
-    "name": "astrotomic/laravel-translatable",
-    "description": "A Laravel package for multilingual models",
-    "keywords": [
-        "laravel",
-        "translation",
-        "language",
-        "database"
-    ],
-    "homepage": "https://astrotomic.info",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Tom Witkowski",
-            "email": "gummibeer@astrotomic.info",
-            "homepage": "https://gummibeer.de",
-            "role": "Developer"
-        },
-        {
-            "name": "Dimitrios Savvopoulos",
-            "email": "ds@dimsav.com",
-            "homepage": "http://dimsav.com",
-            "role": "Developer"
-        }
-    ],
-    "require": {
-        "php": ">=7.2",
-        "illuminate/contracts": "5.8.* || ^6.0 || ^7.0",
-        "illuminate/database": "5.8.* || ^6.0 || ^7.0",
-        "illuminate/support": "5.8.* || ^6.0 || ^7.0"
-    },
-    "require-dev": {
-        "orchestra/testbench": "3.8.* || ^4.0 || ^5.0",
-        "phpunit/phpunit": "^8.0 || ^9.0"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Astrotomic\\Translatable\\TranslatableServiceProvider"
-            ]
-        }
-    },
-    "autoload": {
-        "psr-4": {
-            "Astrotomic\\Translatable\\": "src/Translatable/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Astrotomic\\Translatable\\Tests\\": "tests/"
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "scripts": {
-        "csfix": "php-cs-fixer fix --using-cache=no",
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html=build"
-    },
-    "support": {
-        "email": "dev@astrotomic.info",
-        "issues": "https://github.com/Astrotomic/laravel-translatable/issues",
-        "source": "https://github.com/Astrotomic/laravel-translatable",
-        "docs": "https://docs.astrotomic.info/laravel-translatable"
-    }
+	"name": "astrotomic/laravel-translatable",
+	"description": "A Laravel package for multilingual models",
+	"keywords": [
+		"laravel",
+		"translation",
+		"language",
+		"database"
+	],
+	"homepage": "https://astrotomic.info",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Tom Witkowski",
+			"email": "gummibeer@astrotomic.info",
+			"homepage": "https://gummibeer.de",
+			"role": "Developer"
+		},
+		{
+			"name": "Dimitrios Savvopoulos",
+			"email": "ds@dimsav.com",
+			"homepage": "http://dimsav.com",
+			"role": "Developer"
+		}
+	],
+	"require": {
+		"php": ">=7.2",
+		"illuminate/contracts": "5.8.* || ^6.0 || ^7.0 || ^8.0",
+		"illuminate/database": "5.8.* || ^6.0 || ^7.0 || ^8.0",
+		"illuminate/support": "5.8.* || ^6.0 || ^7.0 || ^8.0"
+	},
+	"require-dev": {
+		"orchestra/testbench": "3.8.* || ^4.0 || ^5.0 || ^6.0",
+		"phpunit/phpunit": "^8.0 || ^9.0"
+	},
+	"config": {
+		"sort-packages": true
+	},
+	"extra": {
+		"laravel": {
+			"providers": [
+				"Astrotomic\\Translatable\\TranslatableServiceProvider"
+			]
+		}
+	},
+	"autoload": {
+		"psr-4": {
+			"Astrotomic\\Translatable\\": "src/Translatable/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Astrotomic\\Translatable\\Tests\\": "tests/"
+		}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"scripts": {
+		"csfix": "php-cs-fixer fix --using-cache=no",
+		"test": "vendor/bin/phpunit",
+		"test-coverage": "vendor/bin/phpunit --coverage-html=build"
+	},
+	"support": {
+		"email": "dev@astrotomic.info",
+		"issues": "https://github.com/Astrotomic/laravel-translatable/issues",
+		"source": "https://github.com/Astrotomic/laravel-translatable",
+		"docs": "https://docs.astrotomic.info/laravel-translatable"
+	}
 }


### PR DESCRIPTION
This pr adds laravel 8.0 support. 

- I added the version for the required composer dependencies and added the laravel version `8.*` to the `run-test.yml` workflow. 
- Additionally requiring legacy factories for `8.*` tests.