### PR TITLE
add blueprint translates macro

### DIFF
--- a/src/Translatable/TranslatableServiceProvider.php
+++ b/src/Translatable/TranslatableServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Astrotomic\Translatable;
 
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\ServiceProvider;
 
 class TranslatableServiceProvider extends ServiceProvider
 {
@@ -29,7 +29,7 @@ class TranslatableServiceProvider extends ServiceProvider
         $this->app->singleton('translatable.locales', Locales::class);
         $this->app->singleton(Locales::class);
     }
-    
+
     protected function registerTranslatesMacro()
     {
         Blueprint::macro('translates', function ($table, $relationColumn = null) {
@@ -42,6 +42,6 @@ class TranslatableServiceProvider extends ServiceProvider
             $this->string('locale')->index();
             $this->unique([$relationColumn, 'locale']);
             $this->foreign($relationColumn)->references('id')->on($table)->onDelete('cascade');
-        });   
+        });
     }
 }

--- a/src/Translatable/TranslatableServiceProvider.php
+++ b/src/Translatable/TranslatableServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Astrotomic\Translatable;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Schema\Blueprint;
 
 class TranslatableServiceProvider extends ServiceProvider
 {
@@ -20,11 +21,27 @@ class TranslatableServiceProvider extends ServiceProvider
         );
 
         $this->registerTranslatableHelper();
+        $this->registerTranslatesMacro();
     }
 
     protected function registerTranslatableHelper()
     {
         $this->app->singleton('translatable.locales', Locales::class);
         $this->app->singleton(Locales::class);
+    }
+    
+    protected function registerTranslatesMacro()
+    {
+        Blueprint::macro('translates', function ($table, $relationColumn = null) {
+            if (is_null($relationColumn)) {
+                $relationColumn = Str::singular($table).'_id';
+            }
+
+            $this->bigIncrements('id');
+            $this->unsignedBigInteger($relationColumn)->unsigned()->index();
+            $this->string('locale')->index();
+            $this->unique([$relationColumn, 'locale']);
+            $this->foreign($relationColumn)->references('id')->on($table)->onDelete('cascade');
+        });   
     }
 }


### PR DESCRIPTION
This pr adds the `translates` macro to `Illuminate\Database\Schema\Blueprint`, which can be used as follows:

```php
Schema::create('post_translations', function (Blueprint $table) {
    $table->translates('posts');

    $table->string('title')->nullable();
    $table->text('text')->nullable();
});
```

You may pass the relation attribute as a second parameter:

```php
$table->translates('posts', 'post_id');
```