### PR TITLE
Translatable.php setAttribute() for attribute casting

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -297,7 +297,7 @@ trait Translatable
         [$attribute, $locale] = $this->getAttributeAndLocale($key);
 
         if ($this->isTranslationAttribute($attribute)) {
-            $this->getTranslationOrNew($locale)->$attribute = $value;
+            $this->getTranslationOrNew($locale)->setAttribute($attribute, $value);
 
             return $this;
         }


### PR DESCRIPTION
Translatable.php setAttribute() instead of $attribute prop assign in order to use translation model casts