### PR TITLE
Laravel 9 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,11 +14,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 7.3, 7.2]
-        laravel: [8.*, 7.*, 6.*, 5.8.*]
+        php: [8.0, 7.4, 7.3, 7.2]
+        laravel: [9.*, 8.*, 7.*, 6.*, 5.8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
+          - laravel: 9.*
+            testbench: 7.*
+            legacy: "laravel/legacy-factories:^1.3"
           - laravel: 8.*
             testbench: 6.*
             legacy: "laravel/legacy-factories:^1.0.4"
@@ -29,10 +32,25 @@ jobs:
           - laravel: 5.8.*
             testbench: 3.8.*
         exclude:
+          - php: 8.0
+            laravel: 5.8.*
           - php: 7.4
             laravel: 5.8.*
+          - php: 8.0
+            laravel: 6.* 
+          - php: 8.0
+            laravel: 7.*
+          - php: 8.0
+            laravel: 8.*
+            dependency-version: prefer-lowest
           - php: 7.2
             laravel: 8.*
+          - php: 7.2
+            laravel: 9.*
+          - php: 7.3
+            laravel: 9.*
+          - php: 7.4
+            laravel: 9.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,13 @@
 {
     "name": "astrotomic/laravel-translatable",
     "description": "A Laravel package for multilingual models",
+    "license": "MIT",
     "keywords": [
         "laravel",
         "translation",
         "language",
         "database"
     ],
-    "homepage": "https://astrotomic.info",
-    "license": "MIT",
     "authors": [
         {
             "name": "Tom Witkowski",
@@ -23,6 +22,13 @@
             "role": "Developer"
         }
     ],
+    "homepage": "https://astrotomic.info",
+    "support": {
+        "email": "dev@astrotomic.info",
+        "issues": "https://github.com/Astrotomic/laravel-translatable/issues",
+        "source": "https://github.com/Astrotomic/laravel-translatable",
+        "docs": "https://docs.astrotomic.info/laravel-translatable"
+    },
     "require": {
         "php": ">=7.2",
         "illuminate/contracts": "5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0",
@@ -32,6 +38,18 @@
     "require-dev": {
         "orchestra/testbench": "3.8.* || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^8.0 || ^9.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "Astrotomic\\Translatable\\": "src/Translatable/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Astrotomic\\Translatable\\Tests\\": "tests/"
+        }
     },
     "config": {
         "sort-packages": true
@@ -43,27 +61,9 @@
             ]
         }
     },
-    "autoload": {
-        "psr-4": {
-            "Astrotomic\\Translatable\\": "src/Translatable/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Astrotomic\\Translatable\\Tests\\": "tests/"
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "scripts": {
         "csfix": "php-cs-fixer fix --using-cache=no",
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html=build"
-    },
-    "support": {
-        "email": "dev@astrotomic.info",
-        "issues": "https://github.com/Astrotomic/laravel-translatable/issues",
-        "source": "https://github.com/Astrotomic/laravel-translatable",
-        "docs": "https://docs.astrotomic.info/laravel-translatable"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/contracts": "5.8.* || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/database": "5.8.* || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/support": "5.8.* || ^6.0 || ^7.0 || ^8.0"
+        "illuminate/contracts": "5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/database": "5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/support": "5.8.* || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "3.8.* || ^4.0 || ^5.0 || ^6.0",
+        "orchestra/testbench": "3.8.* || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^8.0 || ^9.0"
     },
     "config": {


### PR DESCRIPTION
This PR adds Laravel 9.0 support and updates the tests matrix to cover PHP 8.