### PR TITLE
feat: Support relational model query on demand

### DIFF
--- a/src/Translatable/Traits/Relationship.php
+++ b/src/Translatable/Traits/Relationship.php
@@ -49,6 +49,11 @@ trait Relationship
         return config('translatable.translation_model_namespace');
     }
 
+    protected function eloquentRelationshipOnlyTranslatedAttributes(): bool
+    {
+        return config('translatable.eloquent_relationship_only_translated_attributes', false);
+    }
+
     /**
      * @internal will change to protected
      */
@@ -77,6 +82,16 @@ trait Relationship
 
     public function translations(): HasMany
     {
-        return $this->hasMany($this->getTranslationModelName(), $this->getTranslationRelationKey());
+        $translationRelationKey = $this->getTranslationRelationKey();
+        $hasMany =  $this->hasMany($this->getTranslationModelName(), $translationRelationKey);
+        if (false === $this->eloquentRelationshipOnlyTranslatedAttributes()) {
+            return $hasMany;
+        }
+        $translatedAttributes = $this->translatedAttributes;
+        if (!in_array($translationRelationKey, $translatedAttributes, true)) {
+            $translatedAttributes[] = $translationRelationKey;
+        }
+        $hasMany->getQuery()->select($translatedAttributes);
+        return $hasMany;
     }
 }

--- a/src/Translatable/Traits/Relationship.php
+++ b/src/Translatable/Traits/Relationship.php
@@ -91,6 +91,9 @@ trait Relationship
         if (!in_array($translationRelationKey, $translatedAttributes, true)) {
             $translatedAttributes[] = $translationRelationKey;
         }
+        if (!in_array($this->getLocaleKey(), $translatedAttributes, true)) {
+            $translatedAttributes[] = $this->getLocaleKey();
+        }
         $hasMany->getQuery()->select($translatedAttributes);
         return $hasMany;
     }

--- a/src/config/translatable.php
+++ b/src/config/translatable.php
@@ -146,4 +146,13 @@ return [
         'prefix' => '%',
         'suffix' => '%',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | When querying the relational model, only the translation field is queried
+    |--------------------------------------------------------------------------
+    | Setting this to true will have a performance improvement
+    | Otherwise the select * query will be executed by default
+     */
+    'eloquent_relationship_only_translated_attributes' => false
 ];


### PR DESCRIPTION
The select * statement will no longer appear when eloquent_relationship_only_translated_attributes is turned on in the configuration file. Easier to comply with company norms.