### PR TITLE
feat(github-actions): Dependabot Github Actions update check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
 version: 2
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  reviewers:
-  - Gummibeer
-  labels:
-  - dependabot
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    reviewers:
+      - Gummibeer
+    labels:
+      - dependabot
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+    reviewers:
+      - Gummibeer
+    labels:
+      - dependabot

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: composer
+  - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"
     open-pull-requests-limit: 10
     reviewers:
-      - Gummibeer
+      - "Gummibeer"
     labels:
-      - dependabot
+      - "dependabot"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"
     reviewers:
-      - Gummibeer
+      - "Gummibeer"
     labels:
-      - dependabot
+      - "dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,9 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "Gummibeer"
-    labels:
-      - "dependabot"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     reviewers:
       - "Gummibeer"
-    labels:
-      - "dependabot"


### PR DESCRIPTION
- [x] Adds checking github actions for updates and thus also creating PR:s for needed updates on github actions
- [x] adds default [labels](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels) per manager