### PR TITLE
method "isEmptyTranslatableAttribute" is true if the translated value is "0"

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -339,7 +339,7 @@ trait Translatable
 
     protected function isEmptyTranslatableAttribute(string $key, $value): bool
     {
-        return empty($value);
+        return $value != '0' && empty($value);
     }
 
     protected function isTranslationDirty(Model $translation): bool


### PR DESCRIPTION
"0" is a value, and as far as translations are concerned, it cannot be treated as empty.