### PR TITLE
Prevent MissingAttributeException errors when Eloquent is in strict mode

### DIFF
--- a/src/Translatable/Traits/Relationship.php
+++ b/src/Translatable/Traits/Relationship.php
@@ -55,11 +55,7 @@ trait Relationship
      */
     public function getTranslationRelationKey(): string
     {
-        if ($this->translationForeignKey) {
-            return $this->translationForeignKey;
-        }
-
-        return $this->getForeignKey();
+        return isset($this->translationForeignKey) ? $this->translationForeignKey : $this->getForeignKey();
     }
 
     public function translation(): HasOne

--- a/src/Translatable/Traits/Relationship.php
+++ b/src/Translatable/Traits/Relationship.php
@@ -25,7 +25,7 @@ trait Relationship
      */
     public function getTranslationModelName(): string
     {
-        return $this->translationModel ?: $this->getTranslationModelNameDefault();
+        return isset($this->translationModel) ? $this->translationModel : $this->getTranslationModelNameDefault();
     }
 
     /**

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -171,7 +171,7 @@ trait Translatable
      */
     public function getLocaleKey(): string
     {
-        return $this->localeKey ?: config('translatable.locale_key', 'locale');
+        return isset($this->localeKey) ? $this->localeKey : config('translatable.locale_key', 'locale');
     }
 
     public function getNewTranslation(string $locale): Model


### PR DESCRIPTION
With the new strict mode for Eloquent (https://laravel.com/docs/9.x/eloquent#configuring-eloquent-strictness) it is no longer allowed to access attributes that aren't explicit fields of the class or hydrated by Eloquent.

This pull request fixes the MissingAttributeExceptions that are thrown due to the way this package checks for class/object specific config overrides.