### PR TITLE
Find non-empty attribute if fallback locale is null

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -402,6 +402,19 @@ trait Translatable
             && $this->usePropertyFallback()
         ) {
             $translation = $this->getTranslation($this->getFallbackLocale(), false);
+
+            if ($this->useAttributeFallback()) {
+                foreach ($this->getLocalesHelper()->all() as $locale) {
+                    $translation_temp = $this->getTranslationByLocaleKey($locale);
+                    if (
+                        $translation_temp instanceof Model
+                        && ! $this->isEmptyTranslatableAttribute($attribute, $translation_temp->$attribute)
+                    ) {
+                        $translation = $translation_temp;
+                        break;
+                    }
+                }
+            }
         }
 
         if ($translation instanceof Model) {
@@ -452,6 +465,11 @@ trait Translatable
     protected function usePropertyFallback(): bool
     {
         return $this->useFallback() && config('translatable.use_property_fallback', false);
+    }
+
+    protected function useAttributeFallback(): bool
+    {
+        return $this->useFallback() && config('translatable.use_attribute_fallback', false);
     }
 
     public function __isset($key)

--- a/src/config/translatable.php
+++ b/src/config/translatable.php
@@ -72,6 +72,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Use fallback per attribute
+    |--------------------------------------------------------------------------
+    |
+    | The attribute fallback feature will return the translated value of
+    | the fallback locale if the attribute is empty for the selected
+    | locale. Note that 'use_fallback' and 'use_property_fallback' must be enabled.
+    |
+     */
+    'use_attribute_fallback' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Fallback Locale
     |--------------------------------------------------------------------------
     |

--- a/tests/Eloquent/Vegetable.php
+++ b/tests/Eloquent/Vegetable.php
@@ -14,7 +14,7 @@ class Vegetable extends Eloquent implements TranslatableContract
 
     public $translationForeignKey = 'vegetable_identity';
 
-    public $translatedAttributes = ['name'];
+    public $translatedAttributes = ['name', 'details'];
 
     protected $fillable = ['quantity'];
 

--- a/tests/Eloquent/VegetableTranslation.php
+++ b/tests/Eloquent/VegetableTranslation.php
@@ -12,5 +12,6 @@ class VegetableTranslation extends Eloquent
         'vegetable_identity',
         'locale',
         'name',
+        'details',
     ];
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -62,6 +62,7 @@ abstract class TestCase extends OrchestraTestCase
             $table->increments('id');
             $table->integer('vegetable_identity')->unsigned();
             $table->string('name')->nullable();
+            $table->string('details')->nullable();
             $table->string('locale')->index();
 
             $table->unique(['vegetable_identity', 'locale']);

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -662,15 +662,15 @@ final class TranslatableTest extends TestCase
     public function can_get_translations_as_array(): void
     {
         $vegetable = factory(Vegetable::class)->create([
-            'name:en' => 'Peas',
-            'name:fr' => 'Pois',
-            'name:de' => 'Erbsen',
+            'en' => ['name' => 'Peas', 'details' => 'Peas are cool'],
+            'fr' => ['name' => 'Pois', 'details' => 'Pois sont cool'],
+            'de' => ['name' => 'Erbsen', 'details' => 'Erbsen sind cool'],
         ]);
 
         static::assertEquals([
-            'de' => ['name' => 'Erbsen'],
-            'en' => ['name' => 'Peas'],
-            'fr' => ['name' => 'Pois'],
+            'de' => ['name' => 'Erbsen', 'details' => 'Erbsen sind cool'],
+            'en' => ['name' => 'Peas', 'details' => 'Peas are cool'],
+            'fr' => ['name' => 'Pois', 'details' => 'Pois sont cool'],
         ], $vegetable->getTranslationsArray());
     }
 
@@ -731,6 +731,62 @@ final class TranslatableTest extends TestCase
         static::assertEquals('Peas', $vegetable->name);
         $this->app->setLocale('fr');
         static::assertEquals('Peas', $vegetable->name);
+    }
+
+    /** @test */
+    public function it_uses_attribute_fallback_if_default_set_and_attribute_is_empty(): void
+    {
+        $this->app->make('config')->set('translatable.use_fallback', true);
+        $this->app->make('config')->set('translatable.use_property_fallback', true);
+        $this->app->make('config')->set('translatable.use_attribute_fallback', true);
+        $this->app->make('config')->set('translatable.fallback_locale', 'fr');
+        $vegetable = new Vegetable();
+        $vegetable->fill([
+            'en' => ['name' => 'Peas', 'details' => 'Peas are cool'],
+            'fr' => ['name' => '', 'details' => 'Pois sont cool'],
+            'de' => ['name' => '', 'details' => 'Erbsen sind cool'],
+        ]);
+
+        $this->app->setLocale('en');
+        static::assertEquals('Peas', $vegetable->name);
+        $this->app->setLocale('fr');
+        static::assertEquals('Peas', $vegetable->name);
+        $this->app->setLocale('fr');
+        static::assertEquals('Peas', $vegetable->name);
+        $this->app->setLocale('en');
+        static::assertEquals('Peas are cool', $vegetable->details);
+        $this->app->setLocale('fr');
+        static::assertEquals('Pois sont cool', $vegetable->details);
+        $this->app->setLocale('de');
+        static::assertEquals('Erbsen sind cool', $vegetable->details);
+    }
+
+    public function it_uses_attribute_fallback_locales_order_if_default_null_and_attribute_is_empty(): void
+    {
+        $this->app->make('config')->set('translatable.use_fallback', true);
+        $this->app->make('config')->set('translatable.use_property_fallback', true);
+        $this->app->make('config')->set('translatable.use_attribute_fallback', true);
+        $this->app->config->set('translatable.locales', ['en', 'fr', 'de']);
+        $this->app->make('config')->set('translatable.fallback_locale', null);
+        $vegetable = new Vegetable();
+        $vegetable->fill([
+            'en' => ['name' => 'Peas', 'details' => 'Peas are cool'],
+            'fr' => ['name' => '', 'details' => 'Pois sont cool'],
+            'de' => ['name' => '', 'details' => 'Erbsen sind cool'],
+        ]);
+
+        $this->app->setLocale('en');
+        static::assertEquals('Peas', $vegetable->name);
+        $this->app->setLocale('fr');
+        static::assertEquals('Peas', $vegetable->name);
+        $this->app->setLocale('fr');
+        static::assertEquals('Peas', $vegetable->name);
+        $this->app->setLocale('en');
+        static::assertEquals('Peas are cool', $vegetable->details);
+        $this->app->setLocale('fr');
+        static::assertEquals('Pois sont cool', $vegetable->details);
+        $this->app->setLocale('de');
+        static::assertEquals('Erbsen sind cool', $vegetable->details);
     }
 
     /** @test */


### PR DESCRIPTION
If a multi-field translation table exists, we should allow falling back to the attribute of another property. This will allow us to get a translation if the particular attribute on the 'Default locale' returned locale is empty.