### PR TITLE
Make compatible with Model::preventAccessingMissingAttributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.phpunit.result.cache
 /build/
 /coverage.clover
+/.idea/
+```

--- a/src/Translatable/Traits/Relationship.php
+++ b/src/Translatable/Traits/Relationship.php
@@ -25,7 +25,10 @@ trait Relationship
      */
     public function getTranslationModelName(): string
     {
-        return $this->translationModel ?: $this->getTranslationModelNameDefault();
+        if (property_exists($this, 'translationModel') && $this->translationModel) {
+            return $this->translationModel;
+        }
+        return $this->getTranslationModelNameDefault();
     }
 
     /**
@@ -55,7 +58,7 @@ trait Relationship
      */
     public function getTranslationRelationKey(): string
     {
-        if ($this->translationForeignKey) {
+        if (property_exists($this, 'translationForeignKey') && $this->translationForeignKey) {
             return $this->translationForeignKey;
         }
 

--- a/src/Translatable/Traits/Relationship.php
+++ b/src/Translatable/Traits/Relationship.php
@@ -28,6 +28,7 @@ trait Relationship
         if (property_exists($this, 'translationModel') && $this->translationModel) {
             return $this->translationModel;
         }
+
         return $this->getTranslationModelNameDefault();
     }
 

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -171,7 +171,10 @@ trait Translatable
      */
     public function getLocaleKey(): string
     {
-        return $this->localeKey ?: config('translatable.locale_key', 'locale');
+        if (property_exists($this, 'localeKey') && $this->localeKey) {
+            return $this->localeKey;
+        }
+        return config('translatable.locale_key', 'locale');
     }
 
     public function getNewTranslation(string $locale): Model

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -174,6 +174,7 @@ trait Translatable
         if (property_exists($this, 'localeKey') && $this->localeKey) {
             return $this->localeKey;
         }
+
         return config('translatable.locale_key', 'locale');
     }
 


### PR DESCRIPTION
Check for the existence of these optional variables before accessing them, so we can use this package with `Model::preventAccessingMissingAttributes()` and `Model::shouldBeStrict()`