### PR TITLE
Allow to use a wrapper when creating multiple translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,27 @@ $post = Post::create($data);
 echo $post->translate('fr')->title; // Mon premier post
 ```
 
+### Filling multiple translations wrapped
+
+You may define a wrapper property when creating new translations. Set the `translations_wrapper` property in translatable config file:
+```php
+'translations_wrapper' => 'translations',
+```
+
+Then just wrap multiple locales using that property:
+```php
+$data = [
+  'author' => 'Gummibeer',
+  'translations' => [
+      'en' => ['title' => 'My first post'],
+      'fr' => ['title' => 'Mon premier post'],
+  ],
+];
+$post = Post::create($data);
+
+echo $post->translate('fr')->title; // Mon premier post
+```
+
 ## Tutorials
 
 - [How To Add Multilingual Support to Eloquent](https://laravel-news.com/how-to-add-multilingual-support-to-eloquent)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $post = Post::create($data);
 echo $post->translate('fr')->title; // Mon premier post
 ```
 
-### Filling multiple translations wrapped
+#### Filling multiple translations wrapped
 
 You may define a wrapper property when creating new translations. Set the `translations_wrapper` property in translatable config file:
 ```php

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,27 @@ $post = Post::create($data);
 echo $post->translate('fr')->title; // Mon premier post
 ```
 
+### Filling multiple translations wrapped
+
+You may define a wrapper property when creating new translations. Set the `translations_wrapper` property in translatable config file:
+```php
+'translations_wrapper' => 'translations',
+```
+
+Then just wrap multiple locales using that property:
+```php
+$data = [
+  'author' => 'Gummibeer',
+  'translations' => [
+      'en' => ['title' => 'My first post'],
+      'fr' => ['title' => 'Mon premier post'],
+  ],
+];
+$post = Post::create($data);
+
+echo $post->translate('fr')->title; // Mon premier post
+```
+
 ## Tutorials
 
 - [How To Add Multilingual Support to Eloquent](https://laravel-news.com/how-to-add-multilingual-support-to-eloquent)

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ $post = Post::create($data);
 echo $post->translate('fr')->title; // Mon premier post
 ```
 
-### Filling multiple translations wrapped
+#### Filling multiple translations wrapped
 
 You may define a wrapper property when creating new translations. Set the `translations_wrapper` property in translatable config file:
 ```php

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -115,6 +115,9 @@ trait Translatable
     public function fill(array $attributes)
     {
         foreach ($attributes as $key => $values) {
+            if ($this->isWrapperAttribute($key)) {
+                $this->fill($values);
+            }
             if (
                 $this->getLocalesHelper()->has($key)
                 && is_array($values)
@@ -277,6 +280,11 @@ trait Translatable
     public function isTranslationAttribute(string $key): bool
     {
         return in_array($key, $this->translatedAttributes);
+    }
+
+    public function isWrapperAttribute(string $key): bool
+    {
+        return $key === config('translatable.translations_wrapper');
     }
 
     public function replicateWithTranslations(?array $except = null): Model

--- a/src/config/translatable.php
+++ b/src/config/translatable.php
@@ -146,4 +146,16 @@ return [
         'prefix' => '%',
         'suffix' => '%',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Translation Wrapper
+    |--------------------------------------------------------------------------
+    | Defines the wrapper for translations when creating multiple translations.
+    | It is set to null by default, so each locale will be model's property.
+    | If you want to wrap the translations with their respective locales inside
+    | a separate model's property, just set it here.
+    |
+     */
+    'translations_wrapper' => null,
 ];

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -227,11 +227,11 @@ final class TranslatableTest extends TestCase
     #[Test]
     public function it_creates_translations_using_wrapped_mass_assignment_and_locales(): void
     {
-        $this->app->make('config')->set('translatable.translations_wrapper', 'translations');
+        $this->app->make('config')->set('translatable.translations_wrapper', '_translation_wrapper');
 
         $vegetable = Vegetable::create([
             'quantity' => 5,
-            'translations' => [
+            '_translation_wrapper' => [
                 'en' => ['name' => 'Peas'],
                 'fr' => ['name' => 'Pois'],
             ],

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -225,6 +225,28 @@ final class TranslatableTest extends TestCase
     }
 
     #[Test]
+    public function it_creates_translations_using_wrapped_mass_assignment_and_locales(): void
+    {
+        $this->app->make('config')->set('translatable.translations_wrapper', 'translations');
+
+        $vegetable = Vegetable::create([
+            'quantity' => 5,
+            'translations' => [
+                'en' => ['name' => 'Peas'],
+                'fr' => ['name' => 'Pois'],
+            ],
+        ]);
+
+        self::assertEquals(5, $vegetable->quantity);
+        self::assertEquals('Peas', $vegetable->translate('en')->name);
+        self::assertEquals('Pois', $vegetable->translate('fr')->name);
+
+        $vegetable = Vegetable::first();
+        self::assertEquals('Peas', $vegetable->translate('en')->name);
+        self::assertEquals('Pois', $vegetable->translate('fr')->name);
+    }
+
+    #[Test]
     public function it_skips_mass_assignment_if_attributes_non_fillable(): void
     {
         $this->expectException(MassAssignmentException::class);


### PR DESCRIPTION
**Description:**
Adding the ability to wrap multiple translations when creating new records.

**Changes:**
Added `translations_wrapper`   config to allow user to set a custom wrapper name.

**Purpose:**
When working with DTOs, we've found it useful to be able to wrap all the translations into a specific property when creating multiple records at once. 

**Benefits:**
Facilitates to create/convert the DTOs and use them for model creation/update.

**Usage:**
Developers can now set a custom wrapper for multiple creation and use it in the following way: 

You may define a wrapper property when creating new translations. Set the `translations_wrapper` property in translatable config file:
```php
'translations_wrapper' => 'translations',
```

Then just wrap multiple locales using that property:
```php
$data = [
  'author' => 'Gummibeer',
  'translations' => [
      'en' => ['title' => 'My first post'],
      'fr' => ['title' => 'Mon premier post'],
  ],
];
$post = Post::create($data);

echo $post->translate('fr')->title; // Mon premier post
