### PR TITLE
Unload relationship after autoload for toArray()

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -72,9 +72,10 @@ trait Translatable
     public function attributesToArray()
     {
         $attributes = parent::attributesToArray();
+        $alreadyLoaded = $this->relationLoaded('translations');
 
         if (
-            (! $this->relationLoaded('translations') && ! $this->toArrayAlwaysLoadsTranslations() && is_null(self::$autoloadTranslations))
+            (! $alreadyLoaded && ! $this->toArrayAlwaysLoadsTranslations() && is_null(self::$autoloadTranslations))
             || self::$autoloadTranslations === false
         ) {
             return $attributes;
@@ -88,6 +89,10 @@ trait Translatable
             }
 
             $attributes[$field] = $this->getAttributeOrFallback(null, $field);
+        }
+
+        if (! $alreadyLoaded && $this->unloadTranslationsAfterToArray()) {
+            $this->unsetRelation('translations');
         }
 
         return $attributes;
@@ -433,6 +438,11 @@ trait Translatable
         }
 
         return $this->translations->firstWhere($this->getLocaleKey(), $key);
+    }
+
+    protected function unloadTranslationsAfterToArray(): bool
+    {
+        return config('translatable.unload_translations_after_to_array', false);
     }
 
     protected function toArrayAlwaysLoadsTranslations(): bool

--- a/src/config/translatable.php
+++ b/src/config/translatable.php
@@ -134,6 +134,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Unload translations after they were auto loaded for to array
+    |--------------------------------------------------------------------------
+    | Setting this to true will remove the translations relationship
+    | from the model after it was auto loadeded by toArray().
+    |
+     */
+    'unload_translations_after_to_array' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Configure the default behavior of the rule factory
     |--------------------------------------------------------------------------
     | The default values used to control the behavior of the RuleFactory.


### PR DESCRIPTION
This makes sure that translations is removed from the model after `toArray()` is called, so it doesn't appear in any API responses.

This option is opt-in and therefor backwards compatible.