### PR TITLE
Accept $locale in withTranslation scope

### DIFF
--- a/src/Translatable/Traits/Scopes.php
+++ b/src/Translatable/Traits/Scopes.php
@@ -106,19 +106,20 @@ trait Scopes
         return $this->scopeWhereTranslation($query, $translationField, $value, $locale, 'whereHas', 'LIKE');
     }
 
-    public function scopeWithTranslation(Builder $query)
+    public function scopeWithTranslation(Builder $query, ?string $locale = null)
     {
+        $locale = $locale ?: $this->locale();
+
         $query->with([
-            'translations' => function (Relation $query) {
+            'translations' => function (Relation $query) use ($locale) {
                 if ($this->useFallback()) {
-                    $locale = $this->locale();
                     $countryFallbackLocale = $this->getFallbackLocale($locale); // e.g. de-DE => de
                     $locales = array_unique([$locale, $countryFallbackLocale, $this->getFallbackLocale()]);
 
                     return $query->whereIn($this->getTranslationsTable().'.'.$this->getLocaleKey(), $locales);
                 }
 
-                return $query->where($this->getTranslationsTable().'.'.$this->getLocaleKey(), $this->locale());
+                return $query->where($this->getTranslationsTable().'.'.$this->getLocaleKey(), $locale);
             },
         ]);
     }


### PR DESCRIPTION
Under some circonstance we want to preview some data in language that are not the current one. But however want to benefit the fallback mechanism.

This PR add ability to specify the locale we want. 

```php
Model::query()->withTranslation("de")->get();
```

As the param is optional, this PR doesn't include breaking changes