### PR TITLE
Fix new translation is missing the relation id for saving

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -181,7 +181,8 @@ trait Translatable
         /** @var Model $translation */
         $translation = new $modelName();
         $translation->setAttribute($this->getLocaleKey(), $locale);
-        $translation->setAttribute($this->translations()->getForeignKeyName(), $this->getKey());
+        $relation = $this->translations();
+        $translation->setAttribute($relation->getForeignKeyName(), $relation->getParentKey());
         $this->translations->add($translation);
 
         return $translation;

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -181,8 +181,7 @@ trait Translatable
         /** @var Model $translation */
         $translation = new $modelName();
         $translation->setAttribute($this->getLocaleKey(), $locale);
-        $relation = $this->translations();
-        $translation->setAttribute($relation->getForeignKeyName(), $relation->getParentKey());
+        $translation->setAttribute($this->getTranslationRelationKey(), $this->getKey());
         $this->translations->add($translation);
 
         return $translation;

--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -181,6 +181,7 @@ trait Translatable
         /** @var Model $translation */
         $translation = new $modelName();
         $translation->setAttribute($this->getLocaleKey(), $locale);
+        $translation->setAttribute($this->translations()->getForeignKeyName(), $this->getKey());
         $this->translations->add($translation);
 
         return $translation;


### PR DESCRIPTION
If we do

```php
$tr = $model->translateOrNew('en');
$tr->some_field = 'abc';
$tr->save();
```

We get a query exception (`Field ..._id doesn't have a default value`) because the package is not setting the relation key

This PR fixes the issue