### PR TITLE
Add missing test for saving translations standalone

### DIFF
--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -342,6 +342,21 @@ final class TranslatableTest extends TestCase
     }
 
     #[Test]
+    public function new_translation_can_be_saved_directly(): void
+    {
+        $vegetable = factory(Vegetable::class)->create();
+
+        $translation = $vegetable->getNewTranslation('en');
+        $translation->name = 'Peas';
+        $translation->save();
+
+        self::assertDatabaseHas('vegetable_translations', [
+            'locale' => 'en',
+            'name' => 'Peas',
+        ]);
+    }
+
+    #[Test]
     public function the_locale_key_is_locale_by_default(): void
     {
         $vegetable = new Vegetable();


### PR DESCRIPTION
The change introduced in PR #418 can be removed without any test failing.