### PR TITLE
Fix regression trying to save empty translations

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -347,6 +347,7 @@ trait Translatable
     {
         $dirtyAttributes = $translation->getDirty();
         unset($dirtyAttributes[$this->getLocaleKey()]);
+        unset($dirtyAttributes[$this->getTranslationRelationKey()]);
 
         return count($dirtyAttributes) > 0;
     }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -764,6 +764,25 @@ final class TranslatableTest extends TestCase
     }
 
     #[Test]
+    public function empty_translations_are_not_saved(): void
+    {
+        $vegetable = new Vegetable();
+        $vegetable->fill([
+            'en' => [],
+            'de' => ['name' => 'Erbsen'],
+        ]);
+
+        $vegetable->save();
+
+        self::assertDatabaseHas('vegetable_translations', [
+            'locale' => 'de',
+            'name' => 'Erbsen',
+        ]);
+
+        self::assertDatabaseMissing('vegetable_translations', ['locale' => 'en']);
+    }
+
+    #[Test]
     public function numeric_translated_attribute(): void
     {
         $this->app->make('config')->set('translatable.fallback_locale', 'de');


### PR DESCRIPTION
The change introduced in #418 broke an application for me. The reason seems to be that the translations table have not null constraints in the translatable attributes and after the change introduced any new empty translation is considered dirty and becomes a candidate to save in `saveTranslations` method.