### PR TITLE
Call original implementation on numeric translated tests

### DIFF
--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -781,7 +781,7 @@ final class TranslatableTest extends TestCase
                     return is_null($value);
                 }
 
-                return empty($value);
+                return parent::isEmptyTranslatableAttribute($key, $value);
             }
         };
 


### PR DESCRIPTION
This test temporary failed while I was writing the test for #424, and took my attention. I think if the original implementation is called from the overrided method the test can catch some change on the original method that affects the behaviour, but I'm not sure about your opinion, so I preferred to create a separated PR for this change so you can accept or reject it independently.