### PR TITLE
Description for translated() scope is wrong

### DIFF
--- a/docs/package/scopes.md
+++ b/docs/package/scopes.md
@@ -18,7 +18,7 @@ Post::notTranslatedIn('en')->get();
 
 ## translated\(\)
 
-Returns all posts not being translated in any locale
+Returns all posts with existing translations
 
 ```php
 Post::translated()->get();


### PR DESCRIPTION
Description for translated() scope is wrong.
If I have no translation, translated() scope is returning nothing. But with at least one translation translated() scope return post