### PR TITLE
Fix wrapped mass assignment with unguarded models

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -117,6 +117,9 @@ trait Translatable
         foreach ($attributes as $key => $values) {
             if ($this->isWrapperAttribute($key)) {
                 $this->fill($values);
+
+                unset($attributes[$key]);
+                continue;
             }
             if (
                 $this->getLocalesHelper()->has($key)

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -247,6 +247,32 @@ final class TranslatableTest extends TestCase
     }
 
     #[Test]
+    public function it_creates_translations_using_wrapped_mass_assignment_and_locales_with_an_unguarded_model(): void
+    {
+        $this->app->make('config')->set('translatable.translations_wrapper', '_translation_wrapper');
+
+        Vegetable::unguard();
+
+        $vegetable = Vegetable::create([
+            'quantity' => 5,
+            '_translation_wrapper' => [
+                'en' => ['name' => 'Peas'],
+                'fr' => ['name' => 'Pois'],
+            ],
+        ]);
+
+        Vegetable::reguard();
+
+        self::assertEquals(5, $vegetable->quantity);
+        self::assertEquals('Peas', $vegetable->translate('en')->name);
+        self::assertEquals('Pois', $vegetable->translate('fr')->name);
+
+        $vegetable = Vegetable::first();
+        self::assertEquals('Peas', $vegetable->translate('en')->name);
+        self::assertEquals('Pois', $vegetable->translate('fr')->name);
+    }
+
+    #[Test]
     public function it_skips_mass_assignment_if_attributes_non_fillable(): void
     {
         $this->expectException(MassAssignmentException::class);


### PR DESCRIPTION
When using the `translations_wrapper` config option in combination with a model factory, an SQL error is thrown. 

```
Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 table vegetables has no column named _translation_wrapper (Connection: testing, SQL: insert into "vegetables" ("quantity", "_translation_wrapper", "updated_at", "created_at") values (5, ?, 2024-09-16 08:52:41, 2024-09-16 08:52:41))
```

This has to do with the fact that eloquent model factories unguard the model before performing a mass assignment. The wrapped attribute is not removed from the attributes array so an attempt is made to insert that into the base model as wel.

This MR fixes that issue. I have accompanied the proposed code with a test to demonstrate its proper functioning.