### PR TITLE
Prevent duplicate left joins in translation order queries.

### DIFF
--- a/src/Translatable/Traits/Scopes.php
+++ b/src/Translatable/Traits/Scopes.php
@@ -54,16 +54,17 @@ trait Scopes
         $localeKey = $this->getLocaleKey();
         $table = $this->getTable();
         $keyName = $this->getKeyName();
-        
+
         $hasLeftJoin = collect($query->getQuery()->joins ?? [])
-            ->contains(fn($join) => $join instanceof JoinClause && $join->table === $translationTable);
-        if (!$hasLeftJoin) {
+            ->contains(fn ($join) => $join instanceof JoinClause && $join->table === $translationTable);
+        if (! $hasLeftJoin) {
             $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $localeKey, $table, $keyName) {
                 $join
                     ->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$keyName}")
                     ->where("{$translationTable}.{$localeKey}", $this->locale());
             });
         }
+
         return $query
             ->with('translations')
             ->select("{$table}.*")

--- a/src/Translatable/Traits/Scopes.php
+++ b/src/Translatable/Traits/Scopes.php
@@ -48,20 +48,18 @@ trait Scopes
         });
     }
 
-    public function scopeOrderByTranslation(Builder $query, string $translationField, string $sortMethod = 'asc')
+    public function scopeOrderByTranslation(Builder $query, string $translationField, string $sortMethod = 'asc', ?string $local = null)
     {
         $translationTable = $this->getTranslationsTable();
-        $localeKey = $this->getLocaleKey();
         $table = $this->getTable();
-        $keyName = $this->getKeyName();
+        $local ??= $this->locale();
 
         $hasLeftJoin = collect($query->getQuery()->joins ?? [])
             ->contains(fn ($join) => $join instanceof JoinClause && $join->table === $translationTable);
         if (! $hasLeftJoin) {
-            $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $localeKey, $table, $keyName) {
-                $join
-                    ->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$keyName}")
-                    ->where("{$translationTable}.{$localeKey}", $this->locale());
+            $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $table, $local) {
+                $join->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$this->getKeyName()}")
+                    ->where("{$translationTable}.{$this->getLocaleKey()}", $local);
             });
         }
 


### PR DESCRIPTION
This pull request modifies the `scopeOrderByTranslation` method in `src/Translatable/Traits/Scopes.php` to improve its functionality and flexibility by adding support for specifying a locale and optimizing the query logic.

### Enhancements to `scopeOrderByTranslation`:

* Added an optional `?string $local = null` parameter to allow specifying a locale directly when ordering translations. If not provided, the method defaults to using the current locale.
* Optimized the query logic by checking for existing `LEFT JOIN` clauses on the translations table before adding a new one, preventing redundant joins and improving query efficiency.
* Removed redundant variables (`$localeKey` and `$keyName`) and streamlined the join logic to use class methods directly for retrieving keys and table names.