### PR TITLE
add PHPDoc hints for IDE property support in traits

### DIFF
--- a/src/Translatable/Translatable.php
+++ b/src/Translatable/Translatable.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Str;
  * @property-read string $translationForeignKey
  * @property-read string $localeKey
  * @property-read bool $useTranslationFallback
+ * @property array $translatedAttributes
  *
  * @mixin Model
  */


### PR DESCRIPTION
This PR adds a PHPDoc annotation for the `$translatedAttributes` property to improve IDE support and developer experience when working with translatable models. It helps make the expected structure and usage of this property clearer during development.