### PR TITLE
Grant workflow write permissions

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'composer.json'
 
+permissions:
+  contents: write
+
 jobs:
   normalize:
     timeout-minutes: 1

--- a/.github/workflows/markdown-normalize.yml
+++ b/.github/workflows/markdown-normalize.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - '*.md'
 
+permissions:
+  contents: write
+
 jobs:
   normalize:
     timeout-minutes: 1


### PR DESCRIPTION
## What changed

- grant `contents: write` to the Composer normalization workflow
- grant `contents: write` to the Markdown normalization workflow

## Why

Both workflows write normalized files back to the repository. Their `GITHUB_TOKEN` therefore needs explicit repository contents write access; without a workflow-level `permissions` declaration, the token may be limited to read access and CodeQL reports the missing permissions declaration.

## Impact

The normalization actions can commit and push their generated changes while retaining only the narrow write scope they require.

## Validation

- parsed both workflow files as YAML
- ran `git diff --check`