### PR TITLE
Prevent duplicate joins when ordering by translations

### DIFF
--- a/src/Translatable/Traits/Scopes.php
+++ b/src/Translatable/Traits/Scopes.php
@@ -54,16 +54,17 @@ trait Scopes
         $localeKey = $this->getLocaleKey();
         $table = $this->getTable();
         $keyName = $this->getKeyName();
-        
+
         $hasLeftJoin = collect($query->getQuery()->joins ?? [])
-            ->contains(fn($join) => $join instanceof JoinClause && $join->table === $translationTable);
-        if (!$hasLeftJoin) {
+            ->contains(fn ($join) => $join instanceof JoinClause && $join->table === $translationTable);
+        if (! $hasLeftJoin) {
             $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $localeKey, $table, $keyName) {
                 $join
                     ->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$keyName}")
                     ->where("{$translationTable}.{$localeKey}", $this->locale());
             });
         }
+
         return $query
             ->with('translations')
             ->select("{$table}.*")

--- a/src/Translatable/Traits/Scopes.php
+++ b/src/Translatable/Traits/Scopes.php
@@ -48,20 +48,18 @@ trait Scopes
         });
     }
 
-    public function scopeOrderByTranslation(Builder $query, string $translationField, string $sortMethod = 'asc')
+    public function scopeOrderByTranslation(Builder $query, string $translationField, string $sortMethod = 'asc', ?string $local = null)
     {
         $translationTable = $this->getTranslationsTable();
-        $localeKey = $this->getLocaleKey();
         $table = $this->getTable();
-        $keyName = $this->getKeyName();
+        $local ??= $this->locale();
 
         $hasLeftJoin = collect($query->getQuery()->joins ?? [])
             ->contains(fn ($join) => $join instanceof JoinClause && $join->table === $translationTable);
         if (! $hasLeftJoin) {
-            $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $localeKey, $table, $keyName) {
-                $join
-                    ->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$keyName}")
-                    ->where("{$translationTable}.{$localeKey}", $this->locale());
+            $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $table, $local) {
+                $join->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$this->getKeyName()}")
+                    ->where("{$translationTable}.{$this->getLocaleKey()}", $local);
             });
         }
 

--- a/src/Translatable/Traits/Scopes.php
+++ b/src/Translatable/Traits/Scopes.php
@@ -48,24 +48,25 @@ trait Scopes
         });
     }
 
-    public function scopeOrderByTranslation(Builder $query, string $translationField, string $sortMethod = 'asc', ?string $local = null)
+    public function scopeOrderByTranslation(Builder $query, string $translationField, string $sortMethod = 'asc', ?string $locale = null)
     {
         $translationTable = $this->getTranslationsTable();
         $table = $this->getTable();
-        $local ??= $this->locale();
+        $locale ??= $this->locale();
 
         $hasLeftJoin = collect($query->getQuery()->joins ?? [])
             ->contains(fn ($join) => $join instanceof JoinClause && $join->table === $translationTable);
-        if (! $hasLeftJoin) {
-            $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $table, $local) {
-                $join->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$this->getKeyName()}")
-                    ->where("{$translationTable}.{$this->getLocaleKey()}", $local);
-            });
-        }
 
         return $query
             ->with('translations')
             ->select("{$table}.*")
+            ->when(! $hasLeftJoin, function (Builder $query) use ($translationTable, $table, $locale) {
+                $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $table, $locale) {
+                    $join
+                        ->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$this->getKeyName()}")
+                        ->where("{$translationTable}.{$this->getLocaleKey()}", $locale);
+                });
+            })
             ->orderBy("{$translationTable}.{$translationField}", $sortMethod);
     }
 

--- a/src/Translatable/Traits/Scopes.php
+++ b/src/Translatable/Traits/Scopes.php
@@ -51,7 +51,9 @@ trait Scopes
     public function scopeOrderByTranslation(Builder $query, string $translationField, string $sortMethod = 'asc')
     {
         $translationTable = $this->getTranslationsTable();
+        $localeKey = $this->getLocaleKey();
         $table = $this->getTable();
+        $keyName = $this->getKeyName();
 
         $hasLeftJoin = collect($query->getQuery()->joins ?? [])
             ->contains(fn ($join) => $join instanceof JoinClause && $join->table === $translationTable);
@@ -59,11 +61,11 @@ trait Scopes
         return $query
             ->with('translations')
             ->select("{$table}.*")
-            ->unless($hasLeftJoin, function (Builder $query) use ($translationTable, $table) {
-                $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $table) {
+            ->unless($hasLeftJoin, function (Builder $query) use ($translationTable, $localeKey, $table, $keyName) {
+                $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $localeKey, $table, $keyName) {
                     $join
-                        ->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$this->getKeyName()}")
-                        ->where("{$translationTable}.{$this->getLocaleKey()}", $this->locale());
+                        ->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$keyName}")
+                        ->where("{$translationTable}.{$localeKey}", $this->locale());
                 });
             })
             ->orderBy("{$translationTable}.{$translationField}", $sortMethod);

--- a/src/Translatable/Traits/Scopes.php
+++ b/src/Translatable/Traits/Scopes.php
@@ -48,11 +48,10 @@ trait Scopes
         });
     }
 
-    public function scopeOrderByTranslation(Builder $query, string $translationField, string $sortMethod = 'asc', ?string $locale = null)
+    public function scopeOrderByTranslation(Builder $query, string $translationField, string $sortMethod = 'asc')
     {
         $translationTable = $this->getTranslationsTable();
         $table = $this->getTable();
-        $locale ??= $this->locale();
 
         $hasLeftJoin = collect($query->getQuery()->joins ?? [])
             ->contains(fn ($join) => $join instanceof JoinClause && $join->table === $translationTable);
@@ -60,11 +59,11 @@ trait Scopes
         return $query
             ->with('translations')
             ->select("{$table}.*")
-            ->when(! $hasLeftJoin, function (Builder $query) use ($translationTable, $table, $locale) {
-                $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $table, $locale) {
+            ->unless($hasLeftJoin, function (Builder $query) use ($translationTable, $table) {
+                $query->leftJoin($translationTable, function (JoinClause $join) use ($translationTable, $table) {
                     $join
                         ->on("{$translationTable}.{$this->getTranslationRelationKey()}", '=', "{$table}.{$this->getKeyName()}")
-                        ->where("{$translationTable}.{$this->getLocaleKey()}", $locale);
+                        ->where("{$translationTable}.{$this->getLocaleKey()}", $this->locale());
                 });
             })
             ->orderBy("{$translationTable}.{$translationField}", $sortMethod);

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -284,15 +284,6 @@ final class ScopesTest extends TestCase
     }
 
     #[Test]
-    public function order_by_translation_sorts_by_key_in_the_given_locale(): void
-    {
-        factory(Country::class)->create(['code' => 'el', 'name:en' => 'Greece', 'name:fr' => 'Grèce']);
-        factory(Country::class)->create(['code' => 'fr', 'name:en' => 'France', 'name:fr' => 'France']);
-
-        self::assertEquals('fr', Country::orderByTranslation('name', 'asc', 'fr')->get()->first()->code);
-    }
-
-    #[Test]
     public function order_by_translation_does_not_add_duplicate_joins(): void
     {
         $query = Country::orderByTranslation('name')->orderByTranslation('name');

--- a/tests/ScopesTest.php
+++ b/tests/ScopesTest.php
@@ -284,6 +284,23 @@ final class ScopesTest extends TestCase
     }
 
     #[Test]
+    public function order_by_translation_sorts_by_key_in_the_given_locale(): void
+    {
+        factory(Country::class)->create(['code' => 'el', 'name:en' => 'Greece', 'name:fr' => 'Grèce']);
+        factory(Country::class)->create(['code' => 'fr', 'name:en' => 'France', 'name:fr' => 'France']);
+
+        self::assertEquals('fr', Country::orderByTranslation('name', 'asc', 'fr')->get()->first()->code);
+    }
+
+    #[Test]
+    public function order_by_translation_does_not_add_duplicate_joins(): void
+    {
+        $query = Country::orderByTranslation('name')->orderByTranslation('name');
+
+        self::assertCount(1, $query->getQuery()->joins);
+    }
+
+    #[Test]
     public function test_order_by_translation_sorts_by_key_asc_even_if_locale_is_missing(): void
     {
         factory(Vegetable::class)->create(['en' => ['name' => 'Potatoes'], 'fr' => ['name' => 'Pommes de Terre']]);


### PR DESCRIPTION
## Summary

- carries PR #454 forward through an in-repository integration branch
- avoids adding the translations join when that table is already joined
- preserves the existing `orderByTranslation()` method signature
- keeps the join in the existing fluent chain with `->unless()` and applies the outstanding review feedback
- adds regression coverage for duplicate joins

## Validation

- `vendor/bin/phpunit` — 156 tests, 341 assertions
- `vendor/bin/pint --test src/Translatable/Traits/Scopes.php tests/ScopesTest.php`
- `vendor/bin/phpstan analyse --no-progress`
